### PR TITLE
Prevent screenshots with secure text field layer on iOS

### DIFF
--- a/ios/Sources/PrivacyScreenPlugin/PrivacyScreen.swift
+++ b/ios/Sources/PrivacyScreenPlugin/PrivacyScreen.swift
@@ -10,6 +10,7 @@ import UIKit
     // With `isSecureTextEntry = true`, iOS marks this layer subtree as capture-protected.
     // We temporarily re-parent the window layer under that subtree to blank screenshots.
     private var screenshotPreventionTextField: UITextField?
+    private weak var screenshotProtectedWindow: UIWindow?
 
     deinit {
         stop()
@@ -87,14 +88,18 @@ import UIKit
 
         secureSublayer.addSublayer(window.layer)
         screenshotPreventionTextField = textField
+        screenshotProtectedWindow = window
     }
 
     private func disableScreenshotPrevention() {
         guard let textField = screenshotPreventionTextField else { return }
-        defer { screenshotPreventionTextField = nil }
+        defer {
+            screenshotPreventionTextField = nil
+            screenshotProtectedWindow = nil
+        }
 
         if let screenLayer = textField.layer.superlayer,
-           let window = currentWindow() {
+           let window = screenshotProtectedWindow {
             screenLayer.addSublayer(window.layer)
         }
         textField.layer.removeFromSuperlayer()

--- a/ios/Sources/PrivacyScreenPlugin/PrivacyScreen.swift
+++ b/ios/Sources/PrivacyScreenPlugin/PrivacyScreen.swift
@@ -73,7 +73,14 @@ import UIKit
 
         screenLayer.addSublayer(textField.layer)
 
-        guard let secureSublayer = textField.layer.sublayers?.last else {
+        let secureSublayer: CALayer?
+        if #available(iOS 17.0, *) {
+            secureSublayer = textField.layer.sublayers?.last ?? textField.layer.sublayers?.first
+        } else {
+            secureSublayer = textField.layer.sublayers?.first ?? textField.layer.sublayers?.last
+        }
+
+        guard let secureSublayer else {
             textField.layer.removeFromSuperlayer()
             return
         }

--- a/ios/Sources/PrivacyScreenPlugin/PrivacyScreen.swift
+++ b/ios/Sources/PrivacyScreenPlugin/PrivacyScreen.swift
@@ -6,6 +6,10 @@ import UIKit
     private var windowProvider: (() -> UIWindow?)?
     private weak var overlayView: UIView?
     private(set) var isEnabled = false
+    // Hidden secure text field used as a protected rendering host.
+    // With `isSecureTextEntry = true`, iOS marks this layer subtree as capture-protected.
+    // We temporarily re-parent the window layer under that subtree to blank screenshots.
+    private var screenshotPreventionTextField: UITextField?
 
     deinit {
         stop()
@@ -46,13 +50,47 @@ import UIKit
         observers.removeAll()
         windowProvider = nil
         hideOverlay()
+        disableScreenshotPrevention()
     }
 
     @objc public func setEnabled(_ enabled: Bool) {
         isEnabled = enabled
-        if !enabled {
+        if enabled {
+            enableScreenshotPrevention()
+        } else {
             hideOverlay()
+            disableScreenshotPrevention()
         }
+    }
+
+    private func enableScreenshotPrevention() {
+        guard screenshotPreventionTextField == nil,
+              let window = currentWindow(),
+              let screenLayer = window.layer.superlayer else { return }
+
+        let textField = UITextField()
+        textField.isSecureTextEntry = true
+
+        screenLayer.addSublayer(textField.layer)
+
+        guard let secureSublayer = textField.layer.sublayers?.last else {
+            textField.layer.removeFromSuperlayer()
+            return
+        }
+
+        secureSublayer.addSublayer(window.layer)
+        screenshotPreventionTextField = textField
+    }
+
+    private func disableScreenshotPrevention() {
+        guard let textField = screenshotPreventionTextField else { return }
+        defer { screenshotPreventionTextField = nil }
+
+        if let screenLayer = textField.layer.superlayer,
+           let window = currentWindow() {
+            screenLayer.addSublayer(window.layer)
+        }
+        textField.layer.removeFromSuperlayer()
     }
 
     private func showOverlayIfNeeded() {


### PR DESCRIPTION
I have created a hidden secure text field used as a protected rendering host.

With `isSecureTextEntry = true`, iOS marks this layer subtree as capture-protected.

Then I temporarily re-parent the window layer under that subtree to blank screenshots.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved privacy screen to more reliably block screenshots and secure on-screen content.
  * Fixed enable/disable behavior and teardown so toggling privacy mode consistently applies and removes protections without visual artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->