### PR TITLE
Fix privacy screen default state

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,29 @@ The most complete doc is available here: https://capgo.app/docs/plugins/privacy-
 ## Install
 
 ```bash
-bun add @capgo/capacitor-privacy-screen
-bunx cap sync
+npm install @capgo/capacitor-privacy-screen
+npx cap sync
+```
+
+## Configuration
+
+Protection is disabled by default. Enable it on native startup with Capacitor config:
+
+```ts
+import type { CapacitorConfig } from '@capacitor/cli';
+
+const config: CapacitorConfig = {
+  appId: 'com.example.app',
+  appName: 'Example',
+  webDir: 'dist',
+  plugins: {
+    PrivacyScreen: {
+      enabled: true,
+    },
+  },
+};
+
+export default config;
 ```
 
 ## Usage
@@ -36,19 +57,19 @@ bunx cap sync
 ```ts
 import { PrivacyScreen } from '@capgo/capacitor-privacy-screen';
 
-await PrivacyScreen.disable();
-
-// Perform a flow where screenshots or previews are acceptable.
-
 await PrivacyScreen.enable();
+
+// Perform a flow where screenshots or previews should be protected.
+
+await PrivacyScreen.disable();
 ```
 
-The plugin enables protection automatically when the native plugin loads, so most apps do not need to call anything on startup.
+Use JavaScript calls when protection should only apply to specific screens or flows.
 
 ## Behavior
 
 - Android uses `WindowManager.LayoutParams.FLAG_SECURE`, which hides app content from screenshots, screen recording, and the recent apps preview.
-- iOS adds a temporary overlay while the app resigns active so the app switcher snapshot does not expose your content.
+- iOS hides app content from screenshots and adds a temporary overlay while the app resigns active so the app switcher snapshot does not expose your content.
 - Web keeps an in-memory enabled flag for API parity, but browsers cannot enforce native privacy-screen behavior.
 
 ## API
@@ -66,7 +87,7 @@ The plugin enables protection automatically when the native plugin loads, so mos
 <docgen-api>
 <!--Update the source file JSDoc comments and rerun docgen to update the docs below-->
 
-Capacitor API for protecting app content from the app switcher preview.
+Capacitor API for protecting app content from screenshots and app-switcher previews.
 
 ### enable()
 
@@ -77,7 +98,7 @@ enable() => Promise<PrivacyScreenStatus>
 Enables the privacy screen.
 
 On Android this sets `FLAG_SECURE`, which also blocks screenshots and screen recording.
-On iOS this restores the app-switcher overlay that hides your app while it is backgrounded.
+On iOS this hides app content from screenshots and restores the app-switcher overlay while backgrounded.
 
 **Returns:** <code>Promise&lt;<a href="#privacyscreenstatus">PrivacyScreenStatus</a>&gt;</code>
 

--- a/android/src/main/java/app/capgo/privacyscreen/PrivacyScreenPlugin.java
+++ b/android/src/main/java/app/capgo/privacyscreen/PrivacyScreenPlugin.java
@@ -14,7 +14,9 @@ public class PrivacyScreenPlugin extends Plugin {
     @Override
     public void load() {
         implementation = new PrivacyScreen(getActivity());
-        implementation.enable();
+        if (getConfig().getBoolean("enabled", false)) {
+            implementation.enable();
+        }
     }
 
     @PluginMethod

--- a/example-app/README.md
+++ b/example-app/README.md
@@ -5,16 +5,16 @@ This Vite project links directly to the local plugin source so you can validate 
 ## Getting started
 
 ```bash
-bun install
-bun run start
+npm install
+npm run start
 ```
 
 To test on native shells:
 
 ```bash
-bunx cap add ios
-bunx cap add android
-bunx cap sync
+npx cap add ios
+npx cap add android
+npx cap sync
 ```
 
-Native shells enable the privacy screen automatically on load. Use the example buttons to disable it temporarily, then re-enable it and confirm the app switcher preview is hidden again.
+Native shells leave the privacy screen disabled unless you enable it in Capacitor config or with JavaScript. Use the example buttons to enable it, then confirm screenshots and app switcher previews are hidden.

--- a/example-app/index.html
+++ b/example-app/index.html
@@ -12,8 +12,8 @@
         <p class="eyebrow">Capgo plugin example</p>
         <h1>Privacy screen control panel</h1>
         <p class="lead">
-          Native builds enable protection automatically. Use the buttons below to inspect or temporarily relax the
-          shield while testing sensitive flows.
+          Native builds leave protection disabled until you enable it in config or JavaScript. Use the buttons below to
+          inspect the shield while testing sensitive flows.
         </p>
       </section>
 

--- a/ios/Sources/PrivacyScreenPlugin/PrivacyScreen.swift
+++ b/ios/Sources/PrivacyScreenPlugin/PrivacyScreen.swift
@@ -20,7 +20,9 @@ import UIKit
         self.windowProvider = windowProvider
 
         guard observers.isEmpty else {
-            setEnabled(true)
+            if isEnabled {
+                enableScreenshotPrevention()
+            }
             return
         }
 
@@ -42,7 +44,9 @@ import UIKit
             }
         ]
 
-        setEnabled(true)
+        if isEnabled {
+            enableScreenshotPrevention()
+        }
     }
 
     @objc public func stop() {

--- a/ios/Sources/PrivacyScreenPlugin/PrivacyScreenPlugin.swift
+++ b/ios/Sources/PrivacyScreenPlugin/PrivacyScreenPlugin.swift
@@ -19,6 +19,7 @@ public class PrivacyScreenPlugin: CAPPlugin, CAPBridgedPlugin {
             self.implementation.start { [weak self] in
                 self?.bridge?.viewController?.view.window
             }
+            self.implementation.setEnabled(self.getConfig().getBoolean("enabled", false))
         }
     }
 

--- a/ios/Tests/PrivacyScreenPluginTests/PrivacyScreenPluginTests.swift
+++ b/ios/Tests/PrivacyScreenPluginTests/PrivacyScreenPluginTests.swift
@@ -2,6 +2,15 @@ import XCTest
 @testable import PrivacyScreenPlugin
 
 class PrivacyScreenPluginTests: XCTestCase {
+    func testStartDoesNotEnableByDefault() {
+        let implementation = PrivacyScreen()
+        implementation.start {
+            nil
+        }
+
+        XCTAssertFalse(implementation.isEnabled)
+    }
+
     func testEnableDisableState() {
         let implementation = PrivacyScreen()
         implementation.setEnabled(true)

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -19,14 +19,26 @@ export interface PrivacyScreenStatus {
 }
 
 /**
- * Capacitor API for protecting app content from the app switcher preview.
+ * Native startup configuration for privacy protection.
+ */
+export interface PrivacyScreenConfig {
+  /**
+   * Enable privacy protection automatically when the native plugin loads.
+   *
+   * @default false
+   */
+  enabled?: boolean;
+}
+
+/**
+ * Capacitor API for protecting app content from screenshots and app-switcher previews.
  */
 export interface PrivacyScreenPlugin {
   /**
    * Enables the privacy screen.
    *
    * On Android this sets `FLAG_SECURE`, which also blocks screenshots and screen recording.
-   * On iOS this restores the app-switcher overlay that hides your app while it is backgrounded.
+   * On iOS this hides app content from screenshots and restores the app-switcher overlay while backgrounded.
    */
   enable(): Promise<PrivacyScreenStatus>;
 

--- a/src/web.ts
+++ b/src/web.ts
@@ -3,7 +3,7 @@ import { WebPlugin } from '@capacitor/core';
 import type { PluginVersionResult, PrivacyScreenPlugin, PrivacyScreenStatus } from './definitions';
 
 export class PrivacyScreenWeb extends WebPlugin implements PrivacyScreenPlugin {
-  private enabled = true;
+  private enabled = false;
 
   async enable(): Promise<PrivacyScreenStatus> {
     this.enabled = true;


### PR DESCRIPTION
## Summary
- keep privacy protection disabled by default on native and web
- honor `plugins.PrivacyScreen.enabled: true` for native startup opt-in
- update docs/example copy for config or JavaScript enablement

## Tests
- bun run lint
- bun run verify
- swift test (fails because this iOS-only package imports UIKit when SwiftPM targets macOS)