### PR TITLE
feat: align privacy screen config API

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Use JavaScript calls when protection should only apply to specific screens or fl
 
 - Android uses `WindowManager.LayoutParams.FLAG_SECURE`, which hides app content from screenshots, screen recording, and the recent apps preview.
 - Android can show a temporary dim or splash overlay for recent-apps and activity-hidden states.
-- iOS hides app content from screenshots and adds a temporary overlay while the app resigns active so the app switcher snapshot does not expose your content, with optional light or dark blur.
+- iOS adds a temporary overlay while the app resigns active so the app-switcher snapshot does not expose your content, with optional light or dark blur. iOS cannot prevent user-initiated screenshots or screen recording.
 - Web keeps an in-memory enabled flag for API parity, but browsers cannot enforce native privacy-screen behavior.
 
 ## API
@@ -120,7 +120,9 @@ enable(config?: PrivacyScreenConfig | undefined) => Promise<PrivacyScreenActionR
 Enables privacy screen protection.
 
 On Android this sets `FLAG_SECURE`, which also blocks screenshots and screen recording.
-On iOS this hides app content from screenshots and restores the app-switcher overlay while backgrounded.
+On iOS this adds an overlay while the app is backgrounded so app content
+does not appear in the app-switcher snapshot. iOS cannot prevent
+user-initiated screenshots or screen recording.
 
 | Param        | Type                                                                | Description                          |
 | ------------ | ------------------------------------------------------------------- | ------------------------------------ |

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ The most complete doc is available here: https://capgo.app/docs/plugins/privacy-
 ## Install
 
 ```bash
-bun add @capgo/capacitor-privacy-screen
-bunx cap sync
+npm install @capgo/capacitor-privacy-screen
+npx cap sync
 ```
 
 ## Usage
@@ -36,9 +36,19 @@ bunx cap sync
 ```ts
 import { PrivacyScreen } from '@capgo/capacitor-privacy-screen';
 
-await PrivacyScreen.disable();
+await PrivacyScreen.enable({
+  android: {
+    dimBackground: true,
+    privacyModeOnActivityHidden: 'splash',
+  },
+  ios: {
+    blurEffect: 'dark',
+  },
+});
 
-// Perform a flow where screenshots or previews are acceptable.
+const { enabled } = await PrivacyScreen.isEnabled();
+
+await PrivacyScreen.disable();
 
 await PrivacyScreen.enable();
 ```
@@ -48,14 +58,15 @@ The plugin enables protection automatically when the native plugin loads, so mos
 ## Behavior
 
 - Android uses `WindowManager.LayoutParams.FLAG_SECURE`, which hides app content from screenshots, screen recording, and the recent apps preview.
-- iOS adds a temporary overlay while the app resigns active so the app switcher snapshot does not expose your content.
+- Android can show a temporary dim or splash overlay for recent-apps and activity-hidden states.
+- iOS adds a temporary overlay while the app resigns active so the app switcher snapshot does not expose your content, with optional light or dark blur.
 - Web keeps an in-memory enabled flag for API parity, but browsers cannot enforce native privacy-screen behavior.
 
 ## API
 
 <docgen-index>
 
-* [`enable()`](#enable)
+* [`enable(...)`](#enable)
 * [`disable()`](#disable)
 * [`isEnabled()`](#isenabled)
 * [`getPluginVersion()`](#getpluginversion)
@@ -68,18 +79,22 @@ The plugin enables protection automatically when the native plugin loads, so mos
 
 Capacitor API for protecting app content from the app switcher preview.
 
-### enable()
+### enable(...)
 
 ```typescript
-enable() => Promise<PrivacyScreenStatus>
+enable(config?: PrivacyScreenConfig | undefined) => Promise<PrivacyScreenActionResult>
 ```
 
-Enables the privacy screen.
+Enables privacy screen protection.
 
 On Android this sets `FLAG_SECURE`, which also blocks screenshots and screen recording.
 On iOS this restores the app-switcher overlay that hides your app while it is backgrounded.
 
-**Returns:** <code>Promise&lt;<a href="#privacyscreenstatus">PrivacyScreenStatus</a>&gt;</code>
+| Param        | Type                                                                | Description                          |
+| ------------ | ------------------------------------------------------------------- | ------------------------------------ |
+| **`config`** | <code><a href="#privacyscreenconfig">PrivacyScreenConfig</a></code> | Optional platform-specific behavior. |
+
+**Returns:** <code>Promise&lt;<a href="#privacyscreenactionresult">PrivacyScreenActionResult</a>&gt;</code>
 
 --------------------
 
@@ -87,14 +102,14 @@ On iOS this restores the app-switcher overlay that hides your app while it is ba
 ### disable()
 
 ```typescript
-disable() => Promise<PrivacyScreenStatus>
+disable() => Promise<PrivacyScreenActionResult>
 ```
 
-Disables the privacy screen.
+Disables privacy screen protection.
 
 Use this only when you explicitly want the current screen to remain visible in system previews.
 
-**Returns:** <code>Promise&lt;<a href="#privacyscreenstatus">PrivacyScreenStatus</a>&gt;</code>
+**Returns:** <code>Promise&lt;<a href="#privacyscreenactionresult">PrivacyScreenActionResult</a>&gt;</code>
 
 --------------------
 
@@ -126,6 +141,25 @@ Returns the native implementation version marker.
 
 
 ### Interfaces
+
+
+#### PrivacyScreenActionResult
+
+Result returned when privacy protection is toggled.
+
+| Prop          | Type                 | Description                             |
+| ------------- | -------------------- | --------------------------------------- |
+| **`success`** | <code>boolean</code> | Whether the native operation completed. |
+
+
+#### PrivacyScreenConfig
+
+Platform-specific privacy screen behavior.
+
+| Prop          | Type                                                                                                                               | Description            |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------------------- | ---------------------- |
+| **`android`** | <code>{ dimBackground?: boolean; preventScreenshots?: boolean; privacyModeOnActivityHidden?: 'none' \| 'dim' \| 'splash'; }</code> | Android-only behavior. |
+| **`ios`**     | <code>{ blurEffect?: 'none' \| 'light' \| 'dark'; }</code>                                                                         | iOS-only behavior.     |
 
 
 #### PrivacyScreenStatus

--- a/android/src/main/java/app/capgo/privacyscreen/PrivacyScreen.java
+++ b/android/src/main/java/app/capgo/privacyscreen/PrivacyScreen.java
@@ -1,21 +1,37 @@
 package app.capgo.privacyscreen;
 
 import android.app.Activity;
+import android.os.Build;
 import android.os.Looper;
 import android.view.Window;
 import android.view.WindowManager;
 
 public class PrivacyScreen {
 
+    public enum PrivacyMode {
+        NONE,
+        DIM,
+        SPLASH
+    }
+
     private final Activity activity;
     private boolean enabled;
+    private boolean dimBackground;
+    private PrivacyMode privacyModeOnActivityHidden = PrivacyMode.NONE;
+    private PrivacyScreenDialog dialog;
 
     public PrivacyScreen(final Activity activity) {
         this.activity = activity;
     }
 
     public void enable() {
+        enable(false, PrivacyMode.NONE);
+    }
+
+    public void enable(final boolean dimBackground, final PrivacyMode privacyModeOnActivityHidden) {
         enabled = true;
+        this.dimBackground = dimBackground;
+        this.privacyModeOnActivityHidden = privacyModeOnActivityHidden;
         runOnMainThread(() -> {
             final Window window = activity.getWindow();
             if (window != null) {
@@ -26,16 +42,88 @@ public class PrivacyScreen {
 
     public void disable() {
         enabled = false;
+        privacyModeOnActivityHidden = PrivacyMode.NONE;
         runOnMainThread(() -> {
             final Window window = activity.getWindow();
             if (window != null) {
                 window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE);
             }
+            dismissPrivacyDialog();
         });
     }
 
     public boolean isEnabled() {
         return enabled;
+    }
+
+    public void handleOnPause() {
+        if (!enabled) {
+            return;
+        }
+
+        switch (privacyModeOnActivityHidden) {
+            case DIM:
+                showPrivacyDialog(true);
+                break;
+            case SPLASH:
+                showPrivacyDialog(false);
+                break;
+            case NONE:
+            default:
+                break;
+        }
+    }
+
+    public void handleOnResume() {
+        onRecentAppsTriggered(false);
+    }
+
+    public void onRecentAppsTriggered(final boolean isRecentAppsOpen) {
+        if (enabled && isRecentAppsOpen) {
+            showPrivacyDialog(dimBackground);
+        } else {
+            runOnMainThread(this::dismissPrivacyDialog);
+        }
+    }
+
+    public void destroy() {
+        runOnMainThread(this::dismissPrivacyDialog);
+    }
+
+    private void showPrivacyDialog(final boolean dim) {
+        runOnMainThread(() -> {
+            if (!isActivityUsable()) {
+                return;
+            }
+
+            if (dialog != null && (dialog.isShowing() || isDialogViewAttachedToWindowManager())) {
+                return;
+            }
+
+            dismissPrivacyDialog();
+            dialog = new PrivacyScreenDialog(activity, dim);
+
+            try {
+                dialog.show();
+            } catch (final RuntimeException ignored) {
+                dialog = null;
+            }
+        });
+    }
+
+    private void dismissPrivacyDialog() {
+        if (dialog != null) {
+            dialog.dismiss();
+            dialog = null;
+        }
+    }
+
+    private boolean isDialogViewAttachedToWindowManager() {
+        return dialog != null && dialog.getWindow() != null && dialog.getWindow().getDecorView().getParent() != null;
+    }
+
+    private boolean isActivityUsable() {
+        return !activity.isFinishing() && (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR1 || !activity.isDestroyed());
     }
 
     private void runOnMainThread(final Runnable action) {

--- a/android/src/main/java/app/capgo/privacyscreen/PrivacyScreen.java
+++ b/android/src/main/java/app/capgo/privacyscreen/PrivacyScreen.java
@@ -16,8 +16,8 @@ public class PrivacyScreen {
 
     private final Activity activity;
     private boolean enabled;
-    private boolean dimBackground;
-    private PrivacyMode privacyModeOnActivityHidden = PrivacyMode.NONE;
+    private volatile boolean dimBackground;
+    private volatile PrivacyMode privacyModeOnActivityHidden = PrivacyMode.NONE;
     private PrivacyScreenDialog dialog;
 
     public PrivacyScreen(final Activity activity) {

--- a/android/src/main/java/app/capgo/privacyscreen/PrivacyScreenDialog.java
+++ b/android/src/main/java/app/capgo/privacyscreen/PrivacyScreenDialog.java
@@ -17,6 +17,7 @@ import android.widget.FrameLayout;
 public class PrivacyScreenDialog extends Dialog {
 
     private static final int DIM_OVERLAY_COLOR = Color.argb(230, 0, 0, 0);
+    private boolean lostFocusOnce;
 
     public PrivacyScreenDialog(final Activity activity, final boolean dimBackground) {
         super(activity, android.R.style.Theme_Translucent_NoTitleBar_Fullscreen);
@@ -42,8 +43,16 @@ public class PrivacyScreenDialog extends Dialog {
     @Override
     public void onWindowFocusChanged(final boolean hasFocus) {
         super.onWindowFocusChanged(hasFocus);
-        hide();
-        new Handler(Looper.getMainLooper()).post(this::dismiss);
+        if (!hasFocus) {
+            lostFocusOnce = true;
+            return;
+        }
+
+        if (lostFocusOnce) {
+            lostFocusOnce = false;
+            hide();
+            new Handler(Looper.getMainLooper()).post(this::dismiss);
+        }
     }
 
     private boolean setSplashContent(final Activity activity) {

--- a/android/src/main/java/app/capgo/privacyscreen/PrivacyScreenDialog.java
+++ b/android/src/main/java/app/capgo/privacyscreen/PrivacyScreenDialog.java
@@ -1,0 +1,72 @@
+package app.capgo.privacyscreen;
+
+import android.annotation.SuppressLint;
+import android.app.Activity;
+import android.app.Dialog;
+import android.graphics.Color;
+import android.graphics.drawable.ColorDrawable;
+import android.os.Handler;
+import android.os.Looper;
+import android.view.MotionEvent;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.Window;
+import android.widget.FrameLayout;
+
+@SuppressLint("DiscouragedApi")
+public class PrivacyScreenDialog extends Dialog {
+
+    private static final int DIM_OVERLAY_COLOR = Color.argb(230, 0, 0, 0);
+
+    public PrivacyScreenDialog(final Activity activity, final boolean dimBackground) {
+        super(activity, android.R.style.Theme_Translucent_NoTitleBar_Fullscreen);
+        requestWindowFeature(Window.FEATURE_NO_TITLE);
+        setCanceledOnTouchOutside(true);
+
+        final Window window = getWindow();
+        if (window != null) {
+            window.setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
+        }
+
+        if (dimBackground || !setSplashContent(activity)) {
+            setDimContent();
+        }
+    }
+
+    @Override
+    public boolean dispatchTouchEvent(final MotionEvent event) {
+        dismiss();
+        return super.dispatchTouchEvent(event);
+    }
+
+    @Override
+    public void onWindowFocusChanged(final boolean hasFocus) {
+        super.onWindowFocusChanged(hasFocus);
+        hide();
+        new Handler(Looper.getMainLooper()).post(this::dismiss);
+    }
+
+    private boolean setSplashContent(final Activity activity) {
+        final int resourceId = activity.getResources().getIdentifier("splash", "drawable", activity.getPackageName());
+        if (resourceId == 0) {
+            return false;
+        }
+
+        final FrameLayout contentView = fullScreenContentView();
+        contentView.setBackgroundResource(resourceId);
+        setContentView(contentView);
+        return true;
+    }
+
+    private void setDimContent() {
+        final View contentView = fullScreenContentView();
+        contentView.setBackgroundColor(DIM_OVERLAY_COLOR);
+        setContentView(contentView);
+    }
+
+    private FrameLayout fullScreenContentView() {
+        final FrameLayout contentView = new FrameLayout(getContext());
+        contentView.setLayoutParams(new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
+        return contentView;
+    }
+}

--- a/android/src/main/java/app/capgo/privacyscreen/PrivacyScreenPlugin.java
+++ b/android/src/main/java/app/capgo/privacyscreen/PrivacyScreenPlugin.java
@@ -1,5 +1,11 @@
 package app.capgo.privacyscreen;
 
+import android.annotation.SuppressLint;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.os.Build;
 import com.getcapacitor.JSObject;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
@@ -9,24 +15,60 @@ import com.getcapacitor.annotation.CapacitorPlugin;
 @CapacitorPlugin(name = "PrivacyScreen")
 public class PrivacyScreenPlugin extends Plugin {
 
-    private PrivacyScreen implementation;
+    private static final String ACTION_CLOSE_SYSTEM_DIALOGS = "android.intent.action.CLOSE_SYSTEM_DIALOGS";
+    private static final String SYSTEM_DIALOG_REASON_KEY = "reason";
+    private static final String SYSTEM_DIALOG_REASON_RECENT_APPS = "recentapps";
+    private static final String SYSTEM_DIALOG_REASON_RECENT_APPS_XIAOMI = "fs_gesture";
 
+    private PrivacyScreen implementation;
+    private boolean receiverRegistered;
+
+    private final BroadcastReceiver recentAppsReceiver = new BroadcastReceiver() {
+        @Override
+        public void onReceive(final Context context, final Intent intent) {
+            if (!ACTION_CLOSE_SYSTEM_DIALOGS.equals(intent.getAction())) {
+                return;
+            }
+
+            final String reason = intent.getStringExtra(SYSTEM_DIALOG_REASON_KEY);
+            if (
+                implementation != null &&
+                (SYSTEM_DIALOG_REASON_RECENT_APPS.equals(reason) || SYSTEM_DIALOG_REASON_RECENT_APPS_XIAOMI.equals(reason))
+            ) {
+                implementation.onRecentAppsTriggered(true);
+            }
+        }
+    };
+
+    @SuppressLint("UnspecifiedRegisterReceiverFlag")
     @Override
     public void load() {
         implementation = new PrivacyScreen(getActivity());
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            getContext().registerReceiver(recentAppsReceiver, new IntentFilter(ACTION_CLOSE_SYSTEM_DIALOGS), Context.RECEIVER_NOT_EXPORTED);
+        } else {
+            getContext().registerReceiver(recentAppsReceiver, new IntentFilter(ACTION_CLOSE_SYSTEM_DIALOGS));
+        }
+        receiverRegistered = true;
         implementation.enable();
     }
 
     @PluginMethod
     public void enable(final PluginCall call) {
-        implementation.enable();
-        call.resolve(status());
+        final JSObject androidConfig = call.getObject("android");
+        final boolean dimBackground = androidConfig != null && androidConfig.optBoolean("dimBackground", false);
+        final PrivacyScreen.PrivacyMode privacyModeOnActivityHidden = parsePrivacyMode(
+            androidConfig != null ? androidConfig.optString("privacyModeOnActivityHidden", "none") : "none"
+        );
+
+        implementation.enable(dimBackground, privacyModeOnActivityHidden);
+        call.resolve(actionResult(true));
     }
 
     @PluginMethod
     public void disable(final PluginCall call) {
         implementation.disable();
-        call.resolve(status());
+        call.resolve(actionResult(true));
     }
 
     @PluginMethod
@@ -41,9 +83,59 @@ public class PrivacyScreenPlugin extends Plugin {
         call.resolve(ret);
     }
 
+    @Override
+    protected void handleOnPause() {
+        super.handleOnPause();
+        if (implementation != null) {
+            implementation.handleOnPause();
+        }
+    }
+
+    @Override
+    protected void handleOnResume() {
+        super.handleOnResume();
+        if (implementation != null) {
+            implementation.handleOnResume();
+        }
+    }
+
+    @Override
+    protected void handleOnDestroy() {
+        if (implementation != null) {
+            implementation.destroy();
+        }
+
+        if (receiverRegistered) {
+            try {
+                getContext().unregisterReceiver(recentAppsReceiver);
+            } catch (final IllegalArgumentException ignored) {
+                // Receiver was already unregistered by Android during teardown.
+            }
+            receiverRegistered = false;
+        }
+
+        super.handleOnDestroy();
+    }
+
+    private JSObject actionResult(final boolean success) {
+        final JSObject ret = status();
+        ret.put("success", success);
+        return ret;
+    }
+
     private JSObject status() {
         final JSObject ret = new JSObject();
         ret.put("enabled", implementation != null && implementation.isEnabled());
         return ret;
+    }
+
+    private PrivacyScreen.PrivacyMode parsePrivacyMode(final String value) {
+        if ("dim".equals(value)) {
+            return PrivacyScreen.PrivacyMode.DIM;
+        }
+        if ("splash".equals(value)) {
+            return PrivacyScreen.PrivacyMode.SPLASH;
+        }
+        return PrivacyScreen.PrivacyMode.NONE;
     }
 }

--- a/android/src/main/java/app/capgo/privacyscreen/PrivacyScreenPlugin.java
+++ b/android/src/main/java/app/capgo/privacyscreen/PrivacyScreenPlugin.java
@@ -45,12 +45,14 @@ public class PrivacyScreenPlugin extends Plugin {
     @Override
     public void load() {
         implementation = new PrivacyScreen(getActivity());
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            getContext().registerReceiver(recentAppsReceiver, new IntentFilter(ACTION_CLOSE_SYSTEM_DIALOGS), Context.RECEIVER_NOT_EXPORTED);
-        } else {
+
+        // ACTION_CLOSE_SYSTEM_DIALOGS is restricted to system apps on Android 12+.
+        // FLAG_SECURE remains active; this receiver only improves legacy recent-apps overlay timing.
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
             getContext().registerReceiver(recentAppsReceiver, new IntentFilter(ACTION_CLOSE_SYSTEM_DIALOGS));
+            receiverRegistered = true;
         }
-        receiverRegistered = true;
+
         if (getConfig().getBoolean("enabled", false)) {
             final JSONObject androidConfig = getConfig().getObject("android");
             implementation.enable(getDimBackground(androidConfig), getPrivacyModeOnActivityHidden(androidConfig));

--- a/ios/Sources/PrivacyScreenPlugin/PrivacyScreen.swift
+++ b/ios/Sources/PrivacyScreenPlugin/PrivacyScreen.swift
@@ -6,6 +6,7 @@ import UIKit
     private var windowProvider: (() -> UIWindow?)?
     private weak var overlayView: UIView?
     private(set) var isEnabled = false
+    private var blurEffectStyle: UIBlurEffect.Style?
     // Hidden secure text field used as a protected rendering host.
     // With `isSecureTextEntry = true`, iOS marks this layer subtree as capture-protected.
     // We temporarily re-parent the window layer under that subtree to blank screenshots.
@@ -43,6 +44,22 @@ import UIKit
         ]
 
         setEnabled(true)
+    }
+
+    @objc public func setBlurEffect(_ blurEffect: String?) {
+        switch blurEffect {
+        case "light":
+            blurEffectStyle = .light
+        case "dark":
+            blurEffectStyle = .dark
+        default:
+            blurEffectStyle = nil
+        }
+
+        if overlayView != nil {
+            hideOverlay()
+            showOverlayIfNeeded()
+        }
     }
 
     @objc public func stop() {
@@ -133,27 +150,20 @@ import UIKit
     }
 
     private func makeOverlayView(frame: CGRect) -> UIView {
+        if let blurEffectStyle = blurEffectStyle {
+            let blurView = UIVisualEffectView(effect: UIBlurEffect(style: blurEffectStyle))
+            blurView.frame = frame
+            return blurView
+        }
+
         if let storyboardView = UIStoryboard(name: "LaunchScreen", bundle: nil).instantiateInitialViewController()?.view {
             storyboardView.frame = frame
             storyboardView.backgroundColor = .systemBackground
             return storyboardView
         }
 
-        let blurView = UIVisualEffectView(effect: UIBlurEffect(style: .systemUltraThinMaterial))
-        blurView.frame = frame
-
-        let shield = UILabel(frame: .zero)
-        shield.translatesAutoresizingMaskIntoConstraints = false
-        shield.text = "Protected"
-        shield.font = UIFont.systemFont(ofSize: 24, weight: .semibold)
-        shield.textColor = .secondaryLabel
-
-        blurView.contentView.addSubview(shield)
-        NSLayoutConstraint.activate([
-            shield.centerXAnchor.constraint(equalTo: blurView.contentView.centerXAnchor),
-            shield.centerYAnchor.constraint(equalTo: blurView.contentView.centerYAnchor)
-        ])
-
-        return blurView
+        let fallbackView = UIView(frame: frame)
+        fallbackView.backgroundColor = .systemBackground
+        return fallbackView
     }
 }

--- a/ios/Sources/PrivacyScreenPlugin/PrivacyScreen.swift
+++ b/ios/Sources/PrivacyScreenPlugin/PrivacyScreen.swift
@@ -56,6 +56,8 @@ import UIKit
             blurEffectStyle = .light
         case "dark":
             blurEffectStyle = .dark
+        case "none":
+            blurEffectStyle = nil
         default:
             blurEffectStyle = nil
         }

--- a/ios/Sources/PrivacyScreenPlugin/PrivacyScreenPlugin.swift
+++ b/ios/Sources/PrivacyScreenPlugin/PrivacyScreenPlugin.swift
@@ -24,9 +24,13 @@ public class PrivacyScreenPlugin: CAPPlugin, CAPBridgedPlugin {
 
     @objc func enable(_ call: CAPPluginCall) {
         DispatchQueue.main.async {
+            if let iosConfig = call.getObject("ios") {
+                self.implementation.setBlurEffect(iosConfig["blurEffect"] as? String)
+            }
             self.implementation.setEnabled(true)
             call.resolve([
-                "enabled": self.implementation.isEnabled
+                "enabled": self.implementation.isEnabled,
+                "success": true
             ])
         }
     }
@@ -35,7 +39,8 @@ public class PrivacyScreenPlugin: CAPPlugin, CAPBridgedPlugin {
         DispatchQueue.main.async {
             self.implementation.setEnabled(false)
             call.resolve([
-                "enabled": self.implementation.isEnabled
+                "enabled": self.implementation.isEnabled,
+                "success": true
             ])
         }
     }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -19,23 +19,92 @@ export interface PrivacyScreenStatus {
 }
 
 /**
+ * Result returned when privacy protection is toggled.
+ */
+export interface PrivacyScreenActionResult extends PrivacyScreenStatus {
+  /**
+   * Whether the native operation completed.
+   */
+  success: boolean;
+}
+
+/**
+ * Platform-specific privacy screen behavior.
+ */
+export interface PrivacyScreenConfig {
+  /**
+   * Android-only behavior.
+   */
+  android?: {
+    /**
+     * Controls how the app appears when the app switcher privacy screen is displayed.
+     *
+     * When `true`, Android shows a dim overlay. When `false`, Android shows the
+     * splash drawable when available and falls back to dimming.
+     *
+     * @default false
+     */
+    dimBackground?: boolean;
+
+    /**
+     * Deprecated upstream compatibility option.
+     *
+     * `FLAG_SECURE` is always applied while the privacy screen is enabled. To allow
+     * screenshots for a screen or flow, call `disable()` before it and `enable()` after it.
+     *
+     * @deprecated This option is ignored and will be removed in a future major version.
+     */
+    preventScreenshots?: boolean;
+
+    /**
+     * Controls how Android appears when the activity is hidden, such as while a
+     * system biometric prompt is displayed.
+     *
+     * - `none`: no temporary overlay
+     * - `dim`: dim overlay
+     * - `splash`: splash drawable when available, otherwise dim overlay
+     *
+     * @default 'none'
+     */
+    privacyModeOnActivityHidden?: 'none' | 'dim' | 'splash';
+  };
+
+  /**
+   * iOS-only behavior.
+   */
+  ios?: {
+    /**
+     * Controls how iOS obscures the app switcher snapshot.
+     *
+     * `light` and `dark` use native blur effects. `none` uses the launch screen
+     * when available and otherwise falls back to a system background.
+     *
+     * @default 'none'
+     */
+    blurEffect?: 'none' | 'light' | 'dark';
+  };
+}
+
+/**
  * Capacitor API for protecting app content from the app switcher preview.
  */
 export interface PrivacyScreenPlugin {
   /**
-   * Enables the privacy screen.
+   * Enables privacy screen protection.
    *
    * On Android this sets `FLAG_SECURE`, which also blocks screenshots and screen recording.
    * On iOS this restores the app-switcher overlay that hides your app while it is backgrounded.
+   *
+   * @param config Optional platform-specific behavior.
    */
-  enable(): Promise<PrivacyScreenStatus>;
+  enable(config?: PrivacyScreenConfig): Promise<PrivacyScreenActionResult>;
 
   /**
-   * Disables the privacy screen.
+   * Disables privacy screen protection.
    *
    * Use this only when you explicitly want the current screen to remain visible in system previews.
    */
-  disable(): Promise<PrivacyScreenStatus>;
+  disable(): Promise<PrivacyScreenActionResult>;
 
   /**
    * Returns the current enabled state.

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -102,7 +102,9 @@ export interface PrivacyScreenPlugin {
    * Enables privacy screen protection.
    *
    * On Android this sets `FLAG_SECURE`, which also blocks screenshots and screen recording.
-   * On iOS this hides app content from screenshots and restores the app-switcher overlay while backgrounded.
+   * On iOS this adds an overlay while the app is backgrounded so app content
+   * does not appear in the app-switcher snapshot. iOS cannot prevent
+   * user-initiated screenshots or screen recording.
    *
    * @param config Optional platform-specific behavior.
    */

--- a/src/web.ts
+++ b/src/web.ts
@@ -1,18 +1,23 @@
 import { WebPlugin } from '@capacitor/core';
 
-import type { PluginVersionResult, PrivacyScreenPlugin, PrivacyScreenStatus } from './definitions';
+import type {
+  PluginVersionResult,
+  PrivacyScreenActionResult,
+  PrivacyScreenPlugin,
+  PrivacyScreenStatus,
+} from './definitions';
 
 export class PrivacyScreenWeb extends WebPlugin implements PrivacyScreenPlugin {
   private enabled = true;
 
-  async enable(): Promise<PrivacyScreenStatus> {
+  async enable(): Promise<PrivacyScreenActionResult> {
     this.enabled = true;
-    return { enabled: this.enabled };
+    return { enabled: this.enabled, success: true };
   }
 
-  async disable(): Promise<PrivacyScreenStatus> {
+  async disable(): Promise<PrivacyScreenActionResult> {
     this.enabled = false;
-    return { enabled: this.enabled };
+    return { enabled: this.enabled, success: true };
   }
 
   async isEnabled(): Promise<PrivacyScreenStatus> {


### PR DESCRIPTION
## Summary
- Add the official Privacy Screen config shape for Android and iOS to the TypeScript API.
- Support Android `dimBackground` and `privacyModeOnActivityHidden` overlays while keeping `FLAG_SECURE` enabled by default.
- Support iOS `blurEffect` for app-switcher protection and return `success` from enable/disable while preserving `enabled` for existing callers.
- Update README usage/API docs from docgen.

## Validation
- `bun run fmt`
- `bun run lint`
- `bun run build`
- `bun run verify`

Reference: https://capacitorjs.com/docs/apis/privacy-screen

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Privacy screen supports platform-specific configuration (Android: dim/splash options for recent-apps/hidden activity; iOS: selectable blur effects) and accepts a config when enabling.
  * Enable/disable now return an action result including success.

* **Documentation**
  * README updated with new install steps and expanded usage examples, API docs, and behavior descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->