### PR TITLE
[codex] fix iOS capture side effects

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Use JavaScript calls when protection should only apply to specific screens or fl
 
 - Android uses `WindowManager.LayoutParams.FLAG_SECURE`, which hides app content from screenshots, screen recording, and the recent apps preview.
 - Android can show a temporary dim or splash overlay for recent-apps and activity-hidden states.
-- iOS adds a temporary overlay while the app resigns active so the app-switcher snapshot does not expose your content, with optional light or dark blur. iOS cannot prevent user-initiated screenshots or screen recording.
+- iOS places app content in a secure rendering subtree while enabled and adds a temporary overlay while the app resigns active so the app-switcher snapshot does not expose your content, with optional light or dark blur.
 - Web keeps an in-memory enabled flag for API parity, but browsers cannot enforce native privacy-screen behavior.
 
 ## API
@@ -109,7 +109,7 @@ Use JavaScript calls when protection should only apply to specific screens or fl
 <docgen-api>
 <!--Update the source file JSDoc comments and rerun docgen to update the docs below-->
 
-Capacitor API for protecting app content from Android screenshots and native app-switcher previews.
+Capacitor API for protecting app content from screenshots, screen recording, and native app-switcher previews.
 
 ### enable(...)
 
@@ -120,9 +120,9 @@ enable(config?: PrivacyScreenConfig | undefined) => Promise<PrivacyScreenActionR
 Enables privacy screen protection.
 
 On Android this sets `FLAG_SECURE`, which also blocks screenshots and screen recording.
-On iOS this adds an overlay while the app is backgrounded so app content
-does not appear in the app-switcher snapshot. iOS cannot prevent
-user-initiated screenshots or screen recording.
+On iOS this places app content in a secure rendering subtree while enabled
+and adds an overlay while the app is backgrounded so app content does not
+appear in the app-switcher snapshot.
 
 | Param        | Type                                                                | Description                          |
 | ------------ | ------------------------------------------------------------------- | ------------------------------------ |

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Use JavaScript calls when protection should only apply to specific screens or fl
 <docgen-api>
 <!--Update the source file JSDoc comments and rerun docgen to update the docs below-->
 
-Capacitor API for protecting app content from screenshots and app-switcher previews.
+Capacitor API for protecting app content from Android screenshots and native app-switcher previews.
 
 ### enable(...)
 

--- a/ios/Sources/PrivacyScreenPlugin/PrivacyScreen.swift
+++ b/ios/Sources/PrivacyScreenPlugin/PrivacyScreen.swift
@@ -8,6 +8,10 @@ import UIKit
     private weak var overlayView: UIView?
     private(set) var isEnabled = false
     private var blurEffectStyle: UIBlurEffect.Style?
+    // Hidden secure text field used as a protected rendering host while enabled.
+    // With `isSecureTextEntry = true`, iOS marks this layer subtree as capture-protected.
+    private var screenshotPreventionTextField: UITextField?
+    private weak var screenshotProtectedWindow: UIWindow?
 
     deinit {
         stop()
@@ -17,6 +21,9 @@ import UIKit
         self.windowProvider = windowProvider
 
         guard observers.isEmpty else {
+            if isEnabled {
+                enableScreenshotPrevention()
+            }
             return
         }
 
@@ -37,6 +44,10 @@ import UIKit
                 self?.hideOverlay()
             }
         ]
+
+        if isEnabled {
+            enableScreenshotPrevention()
+        }
     }
 
     @objc public func setBlurEffect(_ blurEffect: String?) {
@@ -63,19 +74,67 @@ import UIKit
         observers.removeAll()
         windowProvider = nil
         hideOverlay()
+        disableScreenshotPrevention()
     }
 
     @objc public func setEnabled(_ enabled: Bool) {
         isEnabled = enabled
         if enabled {
+            enableScreenshotPrevention()
             showOverlayIfAppIsInactive()
         } else {
             hideOverlay()
+            disableScreenshotPrevention()
         }
     }
 
     func setApplicationStateProvider(_ provider: @escaping () -> UIApplication.State) {
         applicationStateProvider = provider
+    }
+
+    var isScreenshotPreventionActive: Bool {
+        screenshotPreventionTextField != nil
+    }
+
+    private func enableScreenshotPrevention() {
+        guard screenshotPreventionTextField == nil,
+              let window = currentWindow(),
+              let screenLayer = window.layer.superlayer else { return }
+
+        let textField = UITextField()
+        textField.isSecureTextEntry = true
+
+        screenLayer.addSublayer(textField.layer)
+
+        let secureSublayer: CALayer?
+        if #available(iOS 17.0, *) {
+            secureSublayer = textField.layer.sublayers?.last ?? textField.layer.sublayers?.first
+        } else {
+            secureSublayer = textField.layer.sublayers?.first ?? textField.layer.sublayers?.last
+        }
+
+        guard let secureSublayer else {
+            textField.layer.removeFromSuperlayer()
+            return
+        }
+
+        secureSublayer.addSublayer(window.layer)
+        screenshotPreventionTextField = textField
+        screenshotProtectedWindow = window
+    }
+
+    private func disableScreenshotPrevention() {
+        guard let textField = screenshotPreventionTextField else { return }
+        defer {
+            screenshotPreventionTextField = nil
+            screenshotProtectedWindow = nil
+        }
+
+        if let screenLayer = textField.layer.superlayer,
+           let window = screenshotProtectedWindow {
+            screenLayer.addSublayer(window.layer)
+        }
+        textField.layer.removeFromSuperlayer()
     }
 
     private func showOverlayIfNeeded() {

--- a/ios/Sources/PrivacyScreenPlugin/PrivacyScreen.swift
+++ b/ios/Sources/PrivacyScreenPlugin/PrivacyScreen.swift
@@ -4,6 +4,7 @@ import UIKit
 @objc public class PrivacyScreen: NSObject {
     private var observers: [NSObjectProtocol] = []
     private var windowProvider: (() -> UIWindow?)?
+    private var applicationStateProvider: () -> UIApplication.State = { UIApplication.shared.applicationState }
     private weak var overlayView: UIView?
     private(set) var isEnabled = false
     private var blurEffectStyle: UIBlurEffect.Style?
@@ -66,9 +67,15 @@ import UIKit
 
     @objc public func setEnabled(_ enabled: Bool) {
         isEnabled = enabled
-        if !enabled {
+        if enabled {
+            showOverlayIfAppIsInactive()
+        } else {
             hideOverlay()
         }
+    }
+
+    func setApplicationStateProvider(_ provider: @escaping () -> UIApplication.State) {
+        applicationStateProvider = provider
     }
 
     private func showOverlayIfNeeded() {
@@ -85,6 +92,14 @@ import UIKit
     private func hideOverlay() {
         overlayView?.removeFromSuperview()
         overlayView = nil
+    }
+
+    private func showOverlayIfAppIsInactive() {
+        guard applicationStateProvider() != .active else {
+            return
+        }
+
+        showOverlayIfNeeded()
     }
 
     private func currentWindow() -> UIWindow? {

--- a/ios/Sources/PrivacyScreenPlugin/PrivacyScreen.swift
+++ b/ios/Sources/PrivacyScreenPlugin/PrivacyScreen.swift
@@ -7,11 +7,6 @@ import UIKit
     private weak var overlayView: UIView?
     private(set) var isEnabled = false
     private var blurEffectStyle: UIBlurEffect.Style?
-    // Hidden secure text field used as a protected rendering host.
-    // With `isSecureTextEntry = true`, iOS marks this layer subtree as capture-protected.
-    // We temporarily re-parent the window layer under that subtree to blank screenshots.
-    private var screenshotPreventionTextField: UITextField?
-    private weak var screenshotProtectedWindow: UIWindow?
 
     deinit {
         stop()
@@ -21,9 +16,6 @@ import UIKit
         self.windowProvider = windowProvider
 
         guard observers.isEmpty else {
-            if isEnabled {
-                enableScreenshotPrevention()
-            }
             return
         }
 
@@ -44,10 +36,6 @@ import UIKit
                 self?.hideOverlay()
             }
         ]
-
-        if isEnabled {
-            enableScreenshotPrevention()
-        }
     }
 
     @objc public func setBlurEffect(_ blurEffect: String?) {
@@ -74,58 +62,13 @@ import UIKit
         observers.removeAll()
         windowProvider = nil
         hideOverlay()
-        disableScreenshotPrevention()
     }
 
     @objc public func setEnabled(_ enabled: Bool) {
         isEnabled = enabled
-        if enabled {
-            enableScreenshotPrevention()
-        } else {
+        if !enabled {
             hideOverlay()
-            disableScreenshotPrevention()
         }
-    }
-
-    private func enableScreenshotPrevention() {
-        guard screenshotPreventionTextField == nil,
-              let window = currentWindow(),
-              let screenLayer = window.layer.superlayer else { return }
-
-        let textField = UITextField()
-        textField.isSecureTextEntry = true
-
-        screenLayer.addSublayer(textField.layer)
-
-        let secureSublayer: CALayer?
-        if #available(iOS 17.0, *) {
-            secureSublayer = textField.layer.sublayers?.last ?? textField.layer.sublayers?.first
-        } else {
-            secureSublayer = textField.layer.sublayers?.first ?? textField.layer.sublayers?.last
-        }
-
-        guard let secureSublayer else {
-            textField.layer.removeFromSuperlayer()
-            return
-        }
-
-        secureSublayer.addSublayer(window.layer)
-        screenshotPreventionTextField = textField
-        screenshotProtectedWindow = window
-    }
-
-    private func disableScreenshotPrevention() {
-        guard let textField = screenshotPreventionTextField else { return }
-        defer {
-            screenshotPreventionTextField = nil
-            screenshotProtectedWindow = nil
-        }
-
-        if let screenLayer = textField.layer.superlayer,
-           let window = screenshotProtectedWindow {
-            screenLayer.addSublayer(window.layer)
-        }
-        textField.layer.removeFromSuperlayer()
     }
 
     private func showOverlayIfNeeded() {

--- a/ios/Tests/PrivacyScreenPluginTests/PrivacyScreenPluginTests.swift
+++ b/ios/Tests/PrivacyScreenPluginTests/PrivacyScreenPluginTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import UIKit
 @testable import PrivacyScreenPlugin
 
 class PrivacyScreenPluginTests: XCTestCase {
@@ -23,6 +24,9 @@ class PrivacyScreenPluginTests: XCTestCase {
     func testEnableDoesNotRequestWindowForLiveCapture() {
         let implementation = PrivacyScreen()
         var requestedWindow = false
+        implementation.setApplicationStateProvider {
+            .active
+        }
         implementation.start {
             requestedWindow = true
             return nil
@@ -31,5 +35,21 @@ class PrivacyScreenPluginTests: XCTestCase {
         implementation.setEnabled(true)
 
         XCTAssertFalse(requestedWindow)
+    }
+
+    func testEnableWhileInactiveRequestsWindowForOverlay() {
+        let implementation = PrivacyScreen()
+        var requestedWindow = false
+        implementation.setApplicationStateProvider {
+            .inactive
+        }
+        implementation.start {
+            requestedWindow = true
+            return nil
+        }
+
+        implementation.setEnabled(true)
+
+        XCTAssertTrue(requestedWindow)
     }
 }

--- a/ios/Tests/PrivacyScreenPluginTests/PrivacyScreenPluginTests.swift
+++ b/ios/Tests/PrivacyScreenPluginTests/PrivacyScreenPluginTests.swift
@@ -19,4 +19,17 @@ class PrivacyScreenPluginTests: XCTestCase {
         implementation.setEnabled(false)
         XCTAssertFalse(implementation.isEnabled)
     }
+
+    func testEnableDoesNotRequestWindowForLiveCapture() {
+        let implementation = PrivacyScreen()
+        var requestedWindow = false
+        implementation.start {
+            requestedWindow = true
+            return nil
+        }
+
+        implementation.setEnabled(true)
+
+        XCTAssertFalse(requestedWindow)
+    }
 }

--- a/ios/Tests/PrivacyScreenPluginTests/PrivacyScreenPluginTests.swift
+++ b/ios/Tests/PrivacyScreenPluginTests/PrivacyScreenPluginTests.swift
@@ -5,11 +5,15 @@ import UIKit
 class PrivacyScreenPluginTests: XCTestCase {
     func testStartDoesNotEnableByDefault() {
         let implementation = PrivacyScreen()
+        var requestedWindow = false
         implementation.start {
-            nil
+            requestedWindow = true
+            return nil
         }
 
         XCTAssertFalse(implementation.isEnabled)
+        XCTAssertFalse(implementation.isScreenshotPreventionActive)
+        XCTAssertFalse(requestedWindow)
     }
 
     func testEnableDisableState() {
@@ -21,7 +25,7 @@ class PrivacyScreenPluginTests: XCTestCase {
         XCTAssertFalse(implementation.isEnabled)
     }
 
-    func testEnableDoesNotRequestWindowForLiveCapture() {
+    func testEnableRequestsWindowForCaptureProtection() {
         let implementation = PrivacyScreen()
         var requestedWindow = false
         implementation.setApplicationStateProvider {
@@ -34,6 +38,20 @@ class PrivacyScreenPluginTests: XCTestCase {
 
         implementation.setEnabled(true)
 
+        XCTAssertTrue(requestedWindow)
+    }
+
+    func testDisableDoesNotRequestWindowWhenNotEnabled() {
+        let implementation = PrivacyScreen()
+        var requestedWindow = false
+        implementation.start {
+            requestedWindow = true
+            return nil
+        }
+
+        implementation.setEnabled(false)
+
+        XCTAssertFalse(implementation.isScreenshotPreventionActive)
         XCTAssertFalse(requestedWindow)
     }
 

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -95,16 +95,16 @@ export interface PrivacyScreenConfig {
 }
 
 /**
- * Capacitor API for protecting app content from Android screenshots and native app-switcher previews.
+ * Capacitor API for protecting app content from screenshots, screen recording, and native app-switcher previews.
  */
 export interface PrivacyScreenPlugin {
   /**
    * Enables privacy screen protection.
    *
    * On Android this sets `FLAG_SECURE`, which also blocks screenshots and screen recording.
-   * On iOS this adds an overlay while the app is backgrounded so app content
-   * does not appear in the app-switcher snapshot. iOS cannot prevent
-   * user-initiated screenshots or screen recording.
+   * On iOS this places app content in a secure rendering subtree while enabled
+   * and adds an overlay while the app is backgrounded so app content does not
+   * appear in the app-switcher snapshot.
    *
    * @param config Optional platform-specific behavior.
    */

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -95,7 +95,7 @@ export interface PrivacyScreenConfig {
 }
 
 /**
- * Capacitor API for protecting app content from screenshots and app-switcher previews.
+ * Capacitor API for protecting app content from Android screenshots and native app-switcher previews.
  */
 export interface PrivacyScreenPlugin {
   /**


### PR DESCRIPTION
## Summary

- Remove the iOS secure text-field layer reparenting path that blacked out screenshots and screen recordings.
- Keep iOS behavior focused on the background/app-switcher overlay.
- Add a regression test that enabling iOS privacy protection does not request the app window for live capture setup.
- Update generated API wording to distinguish Android screenshot protection from native app-switcher preview protection.

## Root cause

The iOS implementation still wrapped the app window layer under a secure `UITextField` subtree. That capture-protected subtree could black out screenshots or recordings, even though the current iOS docs say the plugin only protects app-switcher/background snapshots.

## Validation

- `bun run lint`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21 ANDROID_HOME="$HOME/Library/Android/sdk" ANDROID_SDK_ROOT="$HOME/Library/Android/sdk" PATH="/opt/homebrew/opt/openjdk@21/bin:$HOME/Library/Android/sdk/platform-tools:$PATH" bun run verify`
- `xcodebuild test -scheme CapgoCapacitorPrivacyScreen -destination 'platform=iOS Simulator,name=iPhone 17'`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated privacy screen docs and API descriptions to clarify protections for Android screenshots and native app-switcher previews, and to explain iOS secure-rendering and background overlay behavior.

* **Tests**
  * Added and improved unit tests covering enable/disable behavior and application-state-dependent overlay requests.

* **Refactor**
  * Adjusted privacy screen overlay behavior to present only when the app is not active and added application-state injection for presentation control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->